### PR TITLE
Change the class used to detect the path to the DebugBundle

### DIFF
--- a/DebugServiceProvider.php
+++ b/DebugServiceProvider.php
@@ -65,9 +65,9 @@ class DebugServiceProvider implements ServiceProviderInterface, BootableProvider
         });
 
         $app['debug.templates_path'] = function () {
-            $r = new \ReflectionClass('Symfony\Bundle\DebugBundle\DependencyInjection\Configuration');
+            $r = new \ReflectionClass('Symfony\Bundle\DebugBundle\DebugBundle');
 
-            return dirname(dirname($r->getFileName())).'/Resources/views';
+            return dirname($r->getFileName()).'/Resources/views';
         };
     }
 


### PR DESCRIPTION
The Configuration class requires the Config component to be installed to be usable, but DebugBundle defines config as an optional dependency.
The DebugBundle class is always usable on the other hand.

Closes #4
